### PR TITLE
Simplify group variable dropdown

### DIFF
--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -401,12 +401,7 @@ class MainWindow(QMainWindow):
         
         self.group_var_combo.addItem("None")
         self.group_var_combo.addItem("subject")
-        
-        if self.raw_data is not None:
-            # Add other potential group variables
-            for col in self.raw_data.columns:
-                if col not in ['subject', 'stimulus', 'x', 'y', 'x_px', 'y_px', 'time_s']:
-                    self.group_var_combo.addItem(col)
+        self.group_var_combo.addItem("stimulus")
         
         self.group_var_combo.blockSignals(False)
     


### PR DESCRIPTION
## Summary
- fix `update_group_variables` to only populate `None`, `subject`, and `stimulus`

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684842c275ec832690834239afb11c39