### PR TITLE
Remove refresh button from filter controls

### DIFF
--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -163,10 +163,7 @@ class MainWindow(QMainWindow):
         filter_layout.addWidget(self.stimulus_combo)
         filter_layout.addStretch(1)
         
-        # Add refresh button
-        self.refresh_btn = QPushButton("Refresh Plots")
-        self.refresh_btn.clicked.connect(self.update_plots)
-        filter_layout.addWidget(self.refresh_btn)
+
         
         self.main_layout.addLayout(filter_layout)
     


### PR DESCRIPTION
## Summary
- remove initialization and placement of `refresh_btn`
- plots still update when the subject or stimulus selection changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684842bb7b848326888058393289aa8f