### PR TITLE
Add effect size calculation with CI

### DIFF
--- a/analysis/group.py
+++ b/analysis/group.py
@@ -6,7 +6,6 @@ import numpy as np
 from typing import Dict, List, Union, Optional, Tuple
 import statsmodels.formula.api as smf
 from scipy import stats
-import pingouin as pg
 
 # Remove all AOI-based group analysis and references. Leave file empty if all group analysis is AOI-based. 
 
@@ -22,22 +21,78 @@ def aggregate_by_group(df: pd.DataFrame, group_var: str, metrics: Optional[List[
     result = pd.concat([means, sems], axis=1).reset_index()
     return result
 
-def compare_groups(df: pd.DataFrame, group_var: str, metric: str) -> pd.DataFrame:
+def _cohens_d(x: np.ndarray, y: np.ndarray) -> float:
+    """Calculate Cohen's d for two independent samples."""
+    nx, ny = len(x), len(y)
+    vx, vy = np.var(x, ddof=1), np.var(y, ddof=1)
+    pooled_std = np.sqrt(((nx - 1) * vx + (ny - 1) * vy) / (nx + ny - 2))
+    if pooled_std == 0:
+        return np.nan
+    return (np.mean(x) - np.mean(y)) / pooled_std
+
+
+def _eta_squared(groups: List[np.ndarray]) -> float:
+    """Calculate eta-squared for one-way ANOVA."""
+    all_vals = np.concatenate(groups)
+    grand_mean = np.mean(all_vals)
+    ss_between = sum(len(g) * (np.mean(g) - grand_mean) ** 2 for g in groups)
+    ss_total = np.sum((all_vals - grand_mean) ** 2)
+    if ss_total == 0:
+        return np.nan
+    return ss_between / ss_total
+
+
+def _bootstrap_ci(func, data: List[np.ndarray], n_boot: int = 1000, ci: float = 0.95) -> Tuple[float, float]:
+    """Bootstrap confidence interval for the given statistic."""
+    stats_bs = []
+    for _ in range(n_boot):
+        samples = [np.random.choice(d, size=len(d), replace=True) for d in data]
+        stats_bs.append(func(*samples))
+    lower = np.percentile(stats_bs, (1 - ci) / 2 * 100)
+    upper = np.percentile(stats_bs, (1 + ci) / 2 * 100)
+    return lower, upper
+
+
+def compare_groups(df: pd.DataFrame, group_var: str, metric: str, ci: bool = False) -> pd.DataFrame:
+    """Compare groups for a given metric using ANOVA or t-test.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input data.
+    group_var : str
+        Column denoting group membership.
+    metric : str
+        Metric column to compare.
+    ci : bool, optional
+        If True, bootstrap 95% confidence interval for the effect size.
     """
-    Compare groups for a given metric using ANOVA or t-test (if 2 groups).
-    """
+
     groups = df[group_var].dropna().unique()
-    data = [df[df[group_var] == g][metric].dropna() for g in groups]
+    data = [df[df[group_var] == g][metric].dropna().to_numpy() for g in groups]
+
     if len(groups) == 2:
         stat, p = stats.ttest_ind(data[0], data[1], equal_var=False)
-        test = 't-test'
+        effect = _cohens_d(data[0], data[1])
+        test = "t-test"
+        ci_low = ci_high = np.nan
+        if ci:
+            ci_low, ci_high = _bootstrap_ci(_cohens_d, data)
     else:
         stat, p = stats.f_oneway(*data)
-        test = 'ANOVA'
+        effect = _eta_squared(data)
+        test = "ANOVA"
+        ci_low = ci_high = np.nan
+        if ci:
+            ci_low, ci_high = _bootstrap_ci(lambda *d: _eta_squared(list(d)), data)
+
     result = pd.DataFrame({
-        'test': [test],
-        'statistic': [stat],
-        'p_value': [p],
-        'groups': [str(groups)]
+        "test": [test],
+        "statistic": [stat],
+        "p_value": [p],
+        "effect_size": [effect],
+        "ci_lower": [ci_low],
+        "ci_upper": [ci_high],
+        "groups": [str(groups)],
     })
-    return result 
+    return result

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -546,10 +546,10 @@ class MainWindow(QMainWindow):
         # Aggregate by group
         from analysis.group import aggregate_by_group, compare_groups
         agg = aggregate_by_group(df, group_var, [metric])
-        comp = compare_groups(df, group_var, metric)
+        comp = compare_groups(df, group_var, metric, ci=True)
 
-        # Update results table
-        self.results_model.update_data(agg)
+        # Update results table with statistical comparison
+        self.results_model.update_data(comp)
 
         # Plot group heatmap (if possible)
         from analysis.viz import plot_group_heatmap
@@ -562,7 +562,16 @@ class MainWindow(QMainWindow):
             QMessageBox.warning(self, "Plot Error", f"Could not plot group heatmap: {str(e)}")
 
         # Show statistical results in a popup
-        msg = f"Test: {comp['test'].iloc[0]}\nStatistic: {comp['statistic'].iloc[0]:.3f}\nP-value: {comp['p_value'].iloc[0]:.4g}\nGroups: {comp['groups'].iloc[0]}"
+        es = comp['effect_size'].iloc[0]
+        msg = (
+            f"Test: {comp['test'].iloc[0]}\n"
+            f"Statistic: {comp['statistic'].iloc[0]:.3f}\n"
+            f"P-value: {comp['p_value'].iloc[0]:.4g}\n"
+            f"Effect size: {es:.3f}\n"
+        )
+        if not np.isnan(comp['ci_lower'].iloc[0]) and not np.isnan(comp['ci_upper'].iloc[0]):
+            msg += f"95% CI: [{comp['ci_lower'].iloc[0]:.3f}, {comp['ci_upper'].iloc[0]:.3f}]\n"
+        msg += f"Groups: {comp['groups'].iloc[0]}"
         QMessageBox.information(self, "Group Comparison Result", msg)
     
     def export_results(self, output_dir: str):


### PR DESCRIPTION
## Summary
- compute Cohen's d or eta-squared in `compare_groups`
- optionally bootstrap 95% confidence intervals
- display effect sizes and CI in Group Analysis results table and popup

## Testing
- `python -m py_compile analysis/group.py gui/viewer.py`


------
https://chatgpt.com/codex/tasks/task_e_684842cda2188326a18c07fadf7cba79