### PR TITLE
Fix metrics tab controls

### DIFF
--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -290,7 +290,10 @@ class MainWindow(QMainWindow):
         metrics_layout.addRow("", self.by_subject_check)
         
         controls_layout.addWidget(metrics_box)
-        
+
+        # Add controls layout to main layout so widgets persist
+        layout.addLayout(controls_layout)
+
         # Plot area
         self.metrics_plot = PlotTab("Metrics")
         layout.addWidget(self.metrics_plot)


### PR DESCRIPTION
## Summary
- keep metric control widgets in the layout so Qt doesn't destroy them

## Testing
- `python -c 'from gui.viewer import MainWindow; print("MainWindow loaded")'` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684849d13d708326922eed37b36791f5