### PR TITLE
Add experiment capture module

### DIFF
--- a/capture/__init__.py
+++ b/capture/__init__.py
@@ -1,0 +1,1 @@
+"""Data capture utilities."""

--- a/capture/experiment.py
+++ b/capture/experiment.py
@@ -1,0 +1,144 @@
+"""Experiment capture utilities using Tobii eye tracker."""
+from __future__ import annotations
+
+import csv
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import pygame
+try:
+    import tobii_research as tr
+except Exception:  # pragma: no cover - library not available in tests
+    tr = None  # type: ignore
+
+
+def calibrate_tracker(tracker: "tr.EyeTracker", screen: pygame.Surface) -> None:
+    """Calibrate the Tobii eye tracker using a simple five point procedure."""
+    if tr is None:
+        raise RuntimeError("tobii_research library is not available")
+
+    calib = tr.ScreenBasedCalibration(tracker)
+    calib.enter_calibration_mode()
+
+    screen_rect = screen.get_rect()
+    points = [
+        (0.1, 0.1),
+        (0.9, 0.1),
+        (0.5, 0.5),
+        (0.1, 0.9),
+        (0.9, 0.9),
+    ]
+    for x_rel, y_rel in points:
+        x = int(screen_rect.width * x_rel)
+        y = int(screen_rect.height * y_rel)
+        screen.fill((0, 0, 0))
+        pygame.draw.circle(screen, (255, 0, 0), (x, y), 20)
+        pygame.display.flip()
+        time.sleep(0.5)
+        calib.collect_data(x_rel, y_rel)
+        time.sleep(0.2)
+
+    calib.compute_and_apply()
+    calib.leave_calibration_mode()
+
+
+def _load_images() -> List[Path]:
+    """Load stimulus image file paths from default folders."""
+    paths: List[Path] = []
+    for folder in [Path("data/current_images"), Path("data/control_images")]:
+        if folder.exists():
+            paths.extend(sorted(folder.glob("*.jpg")))
+            paths.extend(sorted(folder.glob("*.png")))
+    return paths
+
+
+def _write_samples(csv_path: Path, samples: List[Dict[str, float]]) -> None:
+    """Write gaze samples to CSV."""
+    if not samples:
+        return
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=samples[0].keys())
+        writer.writeheader()
+        writer.writerows(samples)
+
+
+def run_experiment(subject_id: str, duration_s: float = 5.0) -> None:
+    """Run the gaze recording experiment for a subject."""
+    if tr is None:
+        raise RuntimeError("tobii_research library is not available")
+
+    trackers = tr.find_all_eyetrackers()
+    if not trackers:
+        raise RuntimeError("No Tobii eye tracker found")
+    tracker = trackers[0]
+
+    pygame.init()
+    screen = pygame.display.set_mode((1280, 720))
+    pygame.mouse.set_visible(False)
+
+    calibrate_tracker(tracker, screen)
+
+    image_paths = _load_images()
+    output_dir = Path("data")
+    output_dir.mkdir(exist_ok=True)
+
+    for img_path in image_paths:
+        gaze_samples: List[Dict[str, float]] = []
+
+        def gaze_callback(gaze_data: Dict) -> None:
+            left = gaze_data.get("left_gaze_point_on_display_area") or (None, None)
+            right = gaze_data.get("right_gaze_point_on_display_area") or (None, None)
+            gaze_samples.append({
+                "system_time_stamp": gaze_data.get("system_time_stamp"),
+                "device_time_stamp": gaze_data.get("device_time_stamp"),
+                "left_x": left[0],
+                "left_y": left[1],
+                "right_x": right[0],
+                "right_y": right[1],
+            })
+
+        tracker.subscribe_to(tr.EYETRACKER_GAZE_DATA, gaze_callback, as_dictionary=True)
+
+        img = pygame.image.load(str(img_path))
+        img_rect = img.get_rect(center=screen.get_rect().center)
+
+        start = time.time()
+        running = True
+        while running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    running = False
+
+            screen.fill((0, 0, 0))
+            screen.blit(img, img_rect)
+            pygame.display.flip()
+
+            if time.time() - start >= duration_s:
+                running = False
+
+        tracker.unsubscribe_from(tr.EYETRACKER_GAZE_DATA, gaze_callback)
+
+        csv_name = f"{subject_id}_{img_path.stem}.csv"
+        _write_samples(output_dir / csv_name, gaze_samples)
+
+    pygame.quit()
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Command line entry point to run the experiment."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run eye tracking experiment")
+    parser.add_argument("subject_id", type=str, help="Subject identifier")
+    args = parser.parse_args(argv)
+
+    run_experiment(args.subject_id)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -14,12 +14,14 @@ from matplotlib.backends.backend_qtagg import (
     NavigationToolbar2QT,
 )
 import json
+import subprocess
 
 from PySide6.QtWidgets import (
-    QApplication, QMainWindow, QTabWidget, QWidget, QVBoxLayout, 
-    QHBoxLayout, QLabel, QPushButton, QComboBox, QFileDialog, 
+    QApplication, QMainWindow, QTabWidget, QWidget, QVBoxLayout,
+    QHBoxLayout, QLabel, QPushButton, QComboBox, QFileDialog,
     QTableView, QSplitter, QMessageBox, QGroupBox, QFormLayout,
-    QCheckBox, QSpinBox, QDoubleSpinBox, QToolBar, QStatusBar
+    QCheckBox, QSpinBox, QDoubleSpinBox, QToolBar, QStatusBar,
+    QInputDialog,
 )
 from PySide6.QtCore import Qt, QSortFilterProxyModel, Signal, Slot, QSize, QModelIndex
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QAction, QIcon
@@ -32,6 +34,7 @@ from analysis.viz import (
 )
 from analysis.metrics import all_metrics, transition_matrix
 import seaborn as sns
+from capture.experiment import run_experiment
 
 
 class PlotTab(QWidget):
@@ -148,7 +151,11 @@ class MainWindow(QMainWindow):
         self.load_action = QAction("Load Data", self)
         self.load_action.triggered.connect(self.load_data_dialog)
         self.toolbar.addAction(self.load_action)
-        
+
+        self.experiment_action = QAction("Run Experiment", self)
+        self.experiment_action.triggered.connect(self.launch_experiment)
+        self.toolbar.addAction(self.experiment_action)
+
         self.toolbar.addSeparator()
         
         self.export_action = QAction("Export Results", self)
@@ -341,6 +348,12 @@ class MainWindow(QMainWindow):
         
         if output_dir:
             self.export_results(output_dir)
+
+    def launch_experiment(self):
+        """Prompt for subject id and run the capture routine in a subprocess."""
+        subject_id, ok = QInputDialog.getText(self, "Run Experiment", "Subject ID:")
+        if ok and subject_id:
+            subprocess.Popen([sys.executable, "-m", "capture.experiment", subject_id])
     
     def load_data(self, file_paths: List[str]):
         """Load eye tracking data from the selected files."""


### PR DESCRIPTION
## Summary
- implement `capture.run_experiment` for launching an eye tracking experiment
- save gaze samples per stimulus image
- spawn the experiment from the GUI using a subprocess

## Testing
- `python -m py_compile capture/experiment.py gui/viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_684c543a55888326b9ce8ae6dde8493f