### PR TITLE
Clean up data collection tab

### DIFF
--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -24,7 +24,7 @@ from PySide6.QtWidgets import (
     QInputDialog,
 
 )
-from PySide6.QtCore import Qt, QSortFilterProxyModel, Signal, Slot, QSize, QModelIndex
+from PySide6.QtCore import Qt, QSortFilterProxyModel, QSize, QModelIndex
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QAction, QIcon
 
 # Import ETL and analysis modules
@@ -35,7 +35,6 @@ from analysis.viz import (
 )
 from analysis.metrics import all_metrics, transition_matrix
 import seaborn as sns
-from capture.experiment import run_experiment
 
 from .data_collection import DataCollectionTab
 
@@ -99,31 +98,6 @@ class DataTableModel(QStandardItemModel):
                 value = str(self.df.iloc[row, col])
                 item = QStandardItem(value)
                 self.setItem(row, col, item)
-
-
-class DataCollectionTab(QWidget):
-    """Tab for running new data collection sessions."""
-
-    start_clicked = Signal(str)
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        layout = QVBoxLayout(self)
-
-        form_layout = QFormLayout()
-        self.subject_edit = QLineEdit()
-        form_layout.addRow("Subject ID:", self.subject_edit)
-        layout.addLayout(form_layout)
-
-        self.start_btn = QPushButton("Start Study")
-        layout.addWidget(self.start_btn)
-        layout.addStretch(1)
-
-        self.start_btn.clicked.connect(self._emit_start)
-
-    def _emit_start(self):
-        subject_id = self.subject_edit.text().strip()
-        self.start_clicked.emit(subject_id)
 
 
 class MainWindow(QMainWindow):
@@ -217,10 +191,6 @@ class MainWindow(QMainWindow):
     
     def create_initial_tabs(self):
         """Create the initial empty tabs."""
-        # Data collection tab (inserted on the left)
-        self.data_collection_tab = DataCollectionTab()
-        self.data_collection_tab.start_clicked.connect(self.start_recording)
-
         # Timeseries tab
         self.timeseries_tab = PlotTab("Time Series")
         self.tabs.addTab(self.timeseries_tab, "Time Series")
@@ -724,12 +694,6 @@ class MainWindow(QMainWindow):
         except Exception as e:
             QMessageBox.warning(self, "Plot Error", f"Could not plot group heatmap: {str(e)}")
 
-    @Slot(str)
-    def start_recording(self, subject_id: str):
-        """Start a new recording session for the given subject."""
-        # Placeholder implementation for upcoming recording routine
-        QMessageBox.information(self, "Start Study", f"Starting study for subject: {subject_id}")
-    
     def export_results(self, output_dir: str):
         """Export results to the specified directory."""
         if self.fixations is None or self.metrics is None:


### PR DESCRIPTION
## Summary
- remove placeholder `DataCollectionTab` definition
- rely on implementation in `gui/data_collection.py`
- drop unused `start_recording` slot
- create a single `DataCollectionTab` instance in the viewer

## Testing
- `python -m py_compile gui/viewer.py gui/data_collection.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5d64f6fc832696522ecc1584d68f