### PR TITLE
Add mixed effects modeling

### DIFF
--- a/analysis/group.py
+++ b/analysis/group.py
@@ -96,3 +96,42 @@ def compare_groups(df: pd.DataFrame, group_var: str, metric: str, ci: bool = Fal
         "groups": [str(groups)],
     })
     return result
+
+
+def mixed_effects_model(df: pd.DataFrame, formula: str, group_var: str) -> pd.DataFrame:
+    """Fit a mixed effects model and return a summary DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input data containing variables for the model.
+    formula : str
+        Patsy formula describing the fixed effects part of the model.
+    group_var : str
+        Column name specifying the grouping variable for random effects.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame summarizing the fitted model parameters with columns
+        ``param``, ``coef``, ``stderr``, ``z`` and ``p_value``. An empty
+        DataFrame is returned if ``df`` is empty or the group column is
+        missing.
+    """
+
+    if df.empty or group_var not in df.columns:
+        return pd.DataFrame()
+
+    model = smf.mixedlm(formula, df, groups=df[group_var])
+    result = model.fit()
+
+    params = result.params
+    summary = pd.DataFrame({
+        "param": params.index,
+        "coef": params.values,
+        "stderr": result.bse,
+        "z": result.tvalues,
+        "p_value": result.pvalues,
+    })
+
+    return summary.reset_index(drop=True)

--- a/analysis/run.py
+++ b/analysis/run.py
@@ -144,9 +144,11 @@ def run_analysis(
         try:
             if 'dwell_prop' in metrics_df.columns:
                 model_results = mixed_effects_model(
-                    fixations_df, formula="dwell_prop ~ subject", group_var="subject"
+                    metrics_df, formula="dwell_prop ~ subject", group_var="subject"
                 )
-                model_results.to_csv(group_dir / "mixed_effects_model.csv", index=False)
+                model_results.to_csv(
+                    group_dir / "mixed_effects_model.csv", index=False
+                )
         except Exception as e:
             logging.error(f"Error running mixed effects model: {e}")
     


### PR DESCRIPTION
## Summary
- implement `mixed_effects_model` using statsmodels
- invoke mixed model analysis in pipeline on metrics

## Testing
- `pytest -q`
- `python -m py_compile analysis/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5d6a05f48326971d80ab58a2ec7e