### PR TITLE
Fix start study button to run experiment

### DIFF
--- a/gui/experiment_runner.py
+++ b/gui/experiment_runner.py
@@ -1,16 +1,16 @@
-"""Minimal experiment runner used for the GUI data collection tab."""
+"""Experiment runner used by the GUI data collection tab."""
 from __future__ import annotations
 
-import time
+from capture.experiment import run_experiment as capture_run_experiment
 
 
 def run_experiment(subject_id: str) -> None:
-    """Simulate running an eye tracking experiment for ``subject_id``.
+    """Run the real experiment for ``subject_id``.
 
-    This placeholder simply sleeps for a short duration but can be
-    replaced with the actual experiment control logic.
+    This simply delegates to :func:`capture.experiment.run_experiment` so that
+    invoking the "Start Study" button from the GUI launches the full pygame
+    window and recording logic.
     """
-    print(f"Running experiment for {subject_id}")
-    # Simulate a delay
-    time.sleep(2)
-    print("Experiment finished")
+
+    capture_run_experiment(subject_id)
+


### PR DESCRIPTION
## Summary
- hook GUI experiment runner up to capture.experiment
- update capture.experiment to load images from `data/current_images`
- save experiment CSVs in `data/csv`
- allow experiment to run without an eye tracker

## Testing
- `SDL_VIDEODRIVER=dummy python - <<'EOF'
from capture.experiment import run_experiment
run_experiment('test', duration_s=0.1)
print('done')
EOF` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684c688f9fe883268020201747526a94