### PR TITLE
Fix experiment start from GUI

### DIFF
--- a/capture/experiment.py
+++ b/capture/experiment.py
@@ -6,6 +6,9 @@ import time
 from pathlib import Path
 from typing import Dict, List
 
+# Resolve the repository root to load data regardless of the cwd
+BASE_DIR = Path(__file__).resolve().parents[1]
+
 import pygame
 try:
     import tobii_research as tr
@@ -45,7 +48,7 @@ def calibrate_tracker(tracker: "tr.EyeTracker", screen: pygame.Surface) -> None:
 
 def _load_images() -> List[Path]:
     """Load stimulus image file paths from the ``data/current_images`` folder."""
-    folder = Path("data/current_images")
+    folder = BASE_DIR / "data" / "current_images"
     paths: List[Path] = []
     if folder.exists():
         paths.extend(sorted(folder.glob("*.jpg")))
@@ -90,7 +93,7 @@ def run_experiment(subject_id: str, duration_s: float = 5.0) -> None:
         print("Running without eye tracker - demo mode")
 
     image_paths = _load_images()
-    output_dir = Path("data/csv")
+    output_dir = BASE_DIR / "data" / "csv"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     for img_path in image_paths:

--- a/gui/experiment_runner.py
+++ b/gui/experiment_runner.py
@@ -1,16 +1,17 @@
 """Experiment runner used by the GUI data collection tab."""
 from __future__ import annotations
 
-from capture.experiment import run_experiment as capture_run_experiment
+import subprocess
+import sys
 
 
 def run_experiment(subject_id: str) -> None:
-    """Run the real experiment for ``subject_id``.
+    """Run the real experiment for ``subject_id`` in a separate process."""
 
-    This simply delegates to :func:`capture.experiment.run_experiment` so that
-    invoking the "Start Study" button from the GUI launches the full pygame
-    window and recording logic.
-    """
-
-    capture_run_experiment(subject_id)
+    # ``capture.experiment`` relies on pygame which fails when executed from a
+    # non-main thread. Running the module via ``subprocess`` avoids this
+    # limitation while still letting the GUI remain responsive.
+    subprocess.run(
+        [sys.executable, "-m", "capture.experiment", subject_id], check=True
+    )
 


### PR DESCRIPTION
## Summary
- launch capture.experiment in a subprocess when starting study
- resolve paths to images and csv data relative to repository
- clean up unused import in experiment runner

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m capture.experiment test_subject --help`


------
https://chatgpt.com/codex/tasks/task_e_684c6f9ba9388326adfbdafdc970a29c