### PR TITLE
Fix start study with missing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,5 +160,8 @@ metrics, and visualizations to a directory of your choice.
 1. Start the application with `python -m gui.viewer`.
 2. Switch to the **Collect Data** tab.
 3. Enter a subject ID and click **Start Study** to begin recording.
-4. After the session, CSV files are saved in the `data` folder using the
+4. Place the stimulus images you want to present in the `data/current_images`
+   directory. If the folder does not exist it will be created automatically.
+   When no images are found a blank window is shown for a few seconds.
+5. After the session, CSV files are saved in the `data` folder using the
    `SubjectID_StimulusID.csv` naming pattern.

--- a/capture/experiment.py
+++ b/capture/experiment.py
@@ -49,10 +49,12 @@ def calibrate_tracker(tracker: "tr.EyeTracker", screen: pygame.Surface) -> None:
 def _load_images() -> List[Path]:
     """Load stimulus image file paths from the ``data/current_images`` folder."""
     folder = BASE_DIR / "data" / "current_images"
+    # Ensure the folder exists so users know where to place images
+    folder.mkdir(parents=True, exist_ok=True)
+
     paths: List[Path] = []
-    if folder.exists():
-        paths.extend(sorted(folder.glob("*.jpg")))
-        paths.extend(sorted(folder.glob("*.png")))
+    paths.extend(sorted(folder.glob("*.jpg")))
+    paths.extend(sorted(folder.glob("*.png")))
     return paths
 
 
@@ -95,6 +97,26 @@ def run_experiment(subject_id: str, duration_s: float = 5.0) -> None:
     image_paths = _load_images()
     output_dir = BASE_DIR / "data" / "csv"
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not image_paths:
+        print("No stimulus images found in data/current_images")
+        start = time.time()
+        running = True
+        while running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                if event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                    running = False
+
+            screen.fill((0, 0, 0))
+            pygame.display.flip()
+
+            if time.time() - start >= duration_s:
+                running = False
+
+        pygame.quit()
+        return
 
     for img_path in image_paths:
         gaze_samples: List[Dict[str, float]] = []


### PR DESCRIPTION
## Summary
- handle missing images directory in capture experiment
- create default directory if needed
- keep the pygame window visible even when no images are found
- document the `data/current_images` folder in README

## Testing
- `timeout 6 python - <<'EOF'
import os, time
os.environ['SDL_VIDEODRIVER']='dummy'
from capture import experiment
experiment.run_experiment('test', duration_s=1.0)
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684c725bc6688326ac2c1eaf316cf02f