### PR TITLE
Add experiment parameter prompts to GUI

### DIFF
--- a/capture/experiment.py
+++ b/capture/experiment.py
@@ -286,9 +286,26 @@ def run_experiment(subject: str, num_images: int, min_dur: float, max_dur: float
 # ---------------------------------------------------------------------------
 
 def main(argv: List[str] | None = None) -> int:
-    _ = argv  # unused for now
-    subject, num, min_d, max_d = prompt_experiment_params()
-    run_experiment(subject, num, min_d, max_d)
+    """Command line entry point for running the experiment."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run gaze experiment")
+    parser.add_argument("--subject", type=str, help="Subject identifier")
+    parser.add_argument("--num-images", type=int, help="Number of images to show")
+    parser.add_argument("--min", dest="min_dur", type=float, help="Minimum display time (s)")
+    parser.add_argument("--max", dest="max_dur", type=float, help="Maximum display time (s)")
+
+    args = parser.parse_args(argv)
+
+    if all(
+        v is not None
+        for v in (args.subject, args.num_images, args.min_dur, args.max_dur)
+    ):
+        params = (args.subject, args.num_images, args.min_dur, args.max_dur)
+    else:
+        params = prompt_experiment_params()
+
+    run_experiment(*params)
     return 0
 
 

--- a/gui/experiment_runner.py
+++ b/gui/experiment_runner.py
@@ -5,13 +5,26 @@ import subprocess
 import sys
 
 
-def run_experiment(subject_id: str) -> None:
+def run_experiment(subject_id: str, num_images: int, min_dur: float, max_dur: float) -> None:
     """Run the real experiment for ``subject_id`` in a separate process."""
 
     # ``capture.experiment`` relies on pygame which fails when executed from a
     # non-main thread. Running the module via ``subprocess`` avoids this
     # limitation while still letting the GUI remain responsive.
     subprocess.run(
-        [sys.executable, "-m", "capture.experiment", subject_id], check=True
+        [
+            sys.executable,
+            "-m",
+            "capture.experiment",
+            "--subject",
+            subject_id,
+            "--num-images",
+            str(num_images),
+            "--min",
+            str(min_dur),
+            "--max",
+            str(max_dur),
+        ],
+        check=True,
     )
 


### PR DESCRIPTION
## Summary
- extend capture.experiment with argparse-based CLI
- update GUI experiment runner to pass new CLI arguments
- prompt for subject ID, number of images, and display durations when starting experiments

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c871b1460832688e5cb49e93d3c99