### PR TITLE
Add per-stimulus background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ files. Once loaded, available subjects and stimuli appear in the drop-down
 filters. Selecting a subject or stimulus updates the plots for that subset, or
 choose **All** to view everything.
 
+The **Load Images** button lets you associate stimulus IDs with image files.
+The filename (without extension) is used as the stimulus ID. When a matching
+image is available the heatmap and scanpath views display it as a background.
+
 In the **Group Analysis** tab pick a group variable (such as `subject` or
 `stimulus`) and a metric (`dwell_prop`, `ttf_ms`, or `n_fixations`). Click
 **Run Analysis** to compute statistics and draw the group heatmap. After

--- a/analysis/viz.py
+++ b/analysis/viz.py
@@ -43,10 +43,16 @@ def plot_gaze_timeseries(df: pd.DataFrame, fig: Optional[Figure] = None) -> Figu
     return fig
 
 
-def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None, 
-                bins: int = 200, sigma: int = 10,
-                screen_size: Tuple[int, int] = (1920, 1080),
-                cmap: str = 'viridis', alpha: float = 0.7) -> Figure:
+def plot_heatmap(
+    df: pd.DataFrame,
+    fig: Optional[Figure] = None,
+    bins: int = 200,
+    sigma: int = 10,
+    screen_size: Tuple[int, int] = (1920, 1080),
+    cmap: str = 'viridis',
+    alpha: float = 0.7,
+    background_image: Optional[str] = None,
+) -> Figure:
     """
     Plot gaze heatmap.
     
@@ -66,6 +72,8 @@ def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None,
         Colormap name, by default 'viridis'
     alpha : float, optional
         Heatmap transparency, by default 0.7
+    background_image : Optional[str], optional
+        Path to background image to show under the heatmap, by default None
     
     Returns:
     --------
@@ -82,6 +90,14 @@ def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None,
     
     # Create heatmap
     ax = fig.add_subplot(111)
+
+    # Add background image if provided
+    if background_image:
+        try:
+            img = plt.imread(background_image)
+            ax.imshow(img, extent=[0, screen_w, screen_h, 0])
+        except Exception as e:
+            print(f"Error loading background image: {e}")
     
     if not valid_data.empty:
         # Create 2D histogram
@@ -336,18 +352,19 @@ def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
     # 1. Scanpath
     if not filtered_fixations.empty:
         fig = plot_scanpath(
-            filtered_fixations, 
+            filtered_fixations,
             screen_size=screen_size,
-            background_image=background_image
+            background_image=background_image,
         )
         fig.savefig(output_path / f"{prefix}scanpath.png", dpi=300, bbox_inches='tight')
         plt.close(fig)
-    
+
     # 2. Heatmap
     if not filtered_fixations.empty:
         fig = plot_heatmap(
             filtered_fixations,
-            screen_size=screen_size
+            screen_size=screen_size,
+            background_image=background_image,
         )
         fig.savefig(output_path / f"{prefix}heatmap.png", dpi=300, bbox_inches='tight')
         plt.close(fig)

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -132,6 +132,7 @@ class MainWindow(QMainWindow):
         self.metrics = None
         self.current_subject = None
         self.current_stimulus = None
+        self.background_images: Dict[str, str] = {}
         
         # UI setup
         self.setup_ui()
@@ -170,6 +171,10 @@ class MainWindow(QMainWindow):
         self.load_action = QAction("Load Data", self)
         self.load_action.triggered.connect(self.load_data_dialog)
         self.toolbar.addAction(self.load_action)
+
+        self.image_action = QAction("Load Images", self)
+        self.image_action.triggered.connect(self.load_image_dialog)
+        self.toolbar.addAction(self.image_action)
 
         self.experiment_action = QAction("Run Experiment", self)
         self.experiment_action.triggered.connect(self.launch_experiment)
@@ -355,6 +360,20 @@ class MainWindow(QMainWindow):
             file_paths = dialog.selectedFiles()
             if file_paths:
                 self.load_data(file_paths)
+
+    def load_image_dialog(self):
+        """Select images to use as backgrounds."""
+        dialog = QFileDialog()
+        dialog.setFileMode(QFileDialog.FileMode.ExistingFiles)
+        dialog.setNameFilter(
+            "Image Files (*.png *.jpg *.jpeg *.bmp *.gif);;All Files (*)"
+        )
+        dialog.setDirectory(str(Path.cwd()))
+
+        if dialog.exec():
+            for path in dialog.selectedFiles():
+                stim_id = Path(path).stem
+                self.background_images[stim_id] = path
     
     def export_dialog(self):
         """Show dialog to export results."""
@@ -584,8 +603,13 @@ class MainWindow(QMainWindow):
             fig = plot_gaze_timeseries(raw_data)
             self.timeseries_tab.set_figure(fig)
             
+            # Determine background image for current stimulus
+            image_path = None
+            if self.current_stimulus:
+                image_path = self.background_images.get(str(self.current_stimulus))
+
             # Update heatmap plot
-            fig = plot_heatmap(raw_data)
+            fig = plot_heatmap(raw_data, background_image=image_path)
             self.heatmap_tab.set_figure(fig)
             
             # Update scanpath plot
@@ -601,7 +625,7 @@ class MainWindow(QMainWindow):
                 ax.set_title('No Scanpath Data')
                 self.scanpath_tab.set_figure(fig)
             else:
-                fig = plot_scanpath(fixations)
+                fig = plot_scanpath(fixations, background_image=image_path)
                 self.scanpath_tab.set_figure(fig)
             
             # Update metrics plot
@@ -781,14 +805,15 @@ class MainWindow(QMainWindow):
             
             # Calculate transition matrix
             transitions, _ = transition_matrix(fixations)
-            
+
             # Save visualizations
             viz_dir = output_path / "visualizations"
             save_all_visualizations(
                 fixations, filtered_metrics, viz_dir,
                 subject=self.current_subject,
                 stimulus=self.current_stimulus,
-                transition_matrix=transitions
+                background_image=self.background_images.get(str(self.current_stimulus)) if self.current_stimulus else None,
+                transition_matrix=transitions,
             )
             
             self.statusBar.showMessage(f"Results exported to {output_dir}")


### PR DESCRIPTION
## Summary
- allow choosing background images in GUI
- support plotting heatmaps and scanpaths with a stimulus image
- export visualizations with the corresponding image background
- document the new Load Images option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654200296c832696759b97dade2b6b