### PR TITLE
Fix immediate rendering of plots

### DIFF
--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -61,6 +61,7 @@ class PlotTab(QWidget):
         self.toolbar = NavigationToolbar2QT(self.canvas, self)
         self.layout.addWidget(self.canvas)
         self.layout.addWidget(self.toolbar)
+        self.canvas.draw()
 
 
 class DataTableModel(QStandardItemModel):


### PR DESCRIPTION
## Summary
- ensure `PlotTab` immediately renders new figures by calling `self.canvas.draw()`

## Testing
- `python -m py_compile gui/viewer.py`

------
https://chatgpt.com/codex/tasks/task_e_68679c598ba08326a03c084d5cfe1a5d