### PR TITLE
Improve image ID parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ filters. Selecting a subject or stimulus updates the plots for that subset, or
 choose **All** to view everything.
 
 The **Load Images** button lets you associate stimulus IDs with image files.
-The filename (without extension) is used as the stimulus ID. When a matching
-image is available the heatmap and scanpath views display it as a background.
+The application now extracts the ID from the filename, so additional text after
+the ID is allowed (e.g. `id081_person.jpg`). When a matching image is available
+the heatmap and scanpath views display it as a background.
 
 In the **Group Analysis** tab pick a group variable (such as `subject` or
 `stimulus`) and a metric (`dwell_prop`, `ttf_ms`, or `n_fixations`). Click

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -4,6 +4,7 @@ Eye-tracking data viewer application.
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+import re
 
 import pandas as pd
 import numpy as np
@@ -51,6 +52,18 @@ from analysis.viz import (
 )
 from analysis.metrics import all_metrics, transition_matrix
 import seaborn as sns
+
+
+def extract_stimulus_id(filename: str) -> str:
+    """Return the stimulus ID extracted from an image filename."""
+    base = Path(filename).stem
+    match = re.search(r"id\d+", base, re.IGNORECASE)
+    if match:
+        return match.group(0)
+    for sep in ["_", "-"]:
+        if sep in base:
+            return base.split(sep)[0]
+    return base
 
 
 
@@ -391,7 +404,7 @@ class MainWindow(QMainWindow):
 
         if dialog.exec():
             for path in dialog.selectedFiles():
-                stim_id = Path(path).stem
+                stim_id = extract_stimulus_id(path)
                 self.background_images[stim_id] = path
     
     def export_dialog(self):


### PR DESCRIPTION
## Summary
- update README instructions for `Load Images`
- parse stimulus ID from image filename
- use new parser when loading background images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ab2e3f148326bebea0615f8970be