### PR TITLE
Add display settings for screen and image sizes

### DIFF
--- a/analysis/run.py
+++ b/analysis/run.py
@@ -78,7 +78,8 @@ def run_analysis(
     trial_durations_dict: Optional[Dict] = None,
     background_images: Optional[Dict] = None,
     generate_visualizations: bool = True,
-    screen_size: Tuple[int, int] = (1920, 1080)
+    screen_size: Tuple[int, int] = (1920, 1080),
+    image_size: Optional[Tuple[int, int]] = None,
 ) -> pd.DataFrame:
     """
     Run the analysis pipeline.
@@ -101,6 +102,9 @@ def run_analysis(
         Whether to generate visualizations, by default True
     screen_size : Tuple[int, int], optional
         Screen dimensions (width, height), by default (1920, 1080)
+    image_size : Optional[Tuple[int, int]], optional
+        Stimulus image dimensions (width, height). If provided the data is
+        centered within the screen dimensions, by default None
     
     Returns:
     --------
@@ -166,10 +170,11 @@ def run_analysis(
         
         # Group visualizations - all subjects, all stimuli
         save_all_visualizations(
-            fixations_df, metrics_df, 
-            viz_dir, 
+            fixations_df, metrics_df,
+            viz_dir,
             transition_matrix=transitions,
-            screen_size=screen_size
+            screen_size=screen_size,
+            image_size=image_size
         )
         
         # Individual subject visualizations
@@ -186,7 +191,8 @@ def run_analysis(
                 subject_dir,
                 subject=subject,
                 transition_matrix=transition_matrix(subj_fixations)[0],
-                screen_size=screen_size
+                screen_size=screen_size,
+                image_size=image_size
             )
             
             # Each stimulus for this subject
@@ -206,7 +212,8 @@ def run_analysis(
                         subject=subject,
                         stimulus=stimulus,
                         background_image=bg_img,
-                        screen_size=screen_size
+                        screen_size=screen_size,
+                        image_size=image_size
                     )
         
         # Stimulus visualizations (across subjects)
@@ -227,7 +234,8 @@ def run_analysis(
                 stimulus_dir,
                 stimulus=stimulus,
                 background_image=bg_img,
-                screen_size=screen_size
+                screen_size=screen_size,
+                image_size=image_size
             )
     
     return metrics_df

--- a/analysis/viz.py
+++ b/analysis/viz.py
@@ -46,6 +46,7 @@ def plot_heatmap(
     bins: int = 200,
     sigma: int = 10,
     screen_size: Tuple[int, int] = (1920, 1080),
+    image_size: Optional[Tuple[int, int]] = None,
     cmap: str = 'viridis',
     alpha: float = 0.7,
     background_image: Optional[str] = None,
@@ -65,6 +66,9 @@ def plot_heatmap(
         Gaussian blur sigma, by default 10
     screen_size : Tuple[int, int], optional
         Screen dimensions (width, height), by default (1920, 1080)
+    image_size : Optional[Tuple[int, int]], optional
+        Stimulus image dimensions (width, height). If provided the data is
+        centered within the screen dimensions, by default None
     cmap : str, optional
         Colormap name, by default 'viridis'
     alpha : float, optional
@@ -81,9 +85,20 @@ def plot_heatmap(
         fig = plt.figure(figsize=(12, 8))
     
     screen_w, screen_h = screen_size
+    img_w, img_h = image_size if image_size else screen_size
+    offset_x = (screen_w - img_w) / 2 if image_size else 0
+    offset_y = (screen_h - img_h) / 2 if image_size else 0
     
     # Filter for valid coordinates
     valid_data = df.dropna(subset=['x_px', 'y_px'])
+    if image_size:
+        valid_data = valid_data.copy()
+        valid_data['x_px'] = valid_data['x_px'] - offset_x
+        valid_data['y_px'] = valid_data['y_px'] - offset_y
+        valid_data = valid_data[
+            (valid_data['x_px'] >= 0) & (valid_data['x_px'] <= img_w) &
+            (valid_data['y_px'] >= 0) & (valid_data['y_px'] <= img_h)
+        ]
     
     # Create heatmap
     ax = fig.add_subplot(111)
@@ -92,7 +107,7 @@ def plot_heatmap(
     if background_image:
         try:
             img = plt.imread(background_image)
-            ax.imshow(img, extent=[0, screen_w, screen_h, 0])
+            ax.imshow(img, extent=[0, img_w, img_h, 0])
         except Exception as e:
             print(f"Error loading background image: {e}")
     
@@ -100,7 +115,7 @@ def plot_heatmap(
         # Create 2D histogram
         hist, x_edges, y_edges = np.histogram2d(
             valid_data['x_px'], valid_data['y_px'],
-            bins=bins, range=[[0, screen_w], [0, screen_h]]
+            bins=bins, range=[[0, img_w], [0, img_h]]
         )
         
         # Apply Gaussian filter for smoothing
@@ -112,7 +127,7 @@ def plot_heatmap(
         
         # Plot heatmap
         im = ax.imshow(
-            heat.T, extent=[0, screen_w, screen_h, 0],
+            heat.T, extent=[0, img_w, img_h, 0],
             cmap=cmap, alpha=alpha
         )
         
@@ -126,10 +141,16 @@ def plot_heatmap(
     return fig
 
 
-def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str], 
-                      fig: Optional[Figure] = None, bins: int = 200, 
-                      sigma: int = 10, screen_size: Tuple[int, int] = (1920, 1080),
-                      cmap: str = 'viridis') -> Figure:
+def plot_group_heatmap(
+    dfs: List[pd.DataFrame],
+    labels: List[str],
+    fig: Optional[Figure] = None,
+    bins: int = 200,
+    sigma: int = 10,
+    screen_size: Tuple[int, int] = (1920, 1080),
+    image_size: Optional[Tuple[int, int]] = None,
+    cmap: str = 'viridis'
+) -> Figure:
     """
     Plot heatmaps for multiple groups.
     
@@ -147,6 +168,9 @@ def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str],
         Gaussian blur sigma, by default 10
     screen_size : Tuple[int, int], optional
         Screen dimensions (width, height), by default (1920, 1080)
+    image_size : Optional[Tuple[int, int]], optional
+        Stimulus image dimensions (width, height). If provided the data is
+        centered within the screen dimensions, by default None
     cmap : str, optional
         Colormap name, by default 'viridis'
     
@@ -163,19 +187,30 @@ def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str],
         raise ValueError("Number of DataFrames must match number of labels")
     
     screen_w, screen_h = screen_size
-    
+    img_w, img_h = image_size if image_size else screen_size
+    offset_x = (screen_w - img_w) / 2 if image_size else 0
+    offset_y = (screen_h - img_h) / 2 if image_size else 0
+
     # Create heatmaps for each group
     heatmaps = []
     
     for i, df in enumerate(dfs):
         # Filter for valid coordinates
         valid_data = df.dropna(subset=['x_px', 'y_px'])
+        if image_size:
+            valid_data = valid_data.copy()
+            valid_data['x_px'] = valid_data['x_px'] - offset_x
+            valid_data['y_px'] = valid_data['y_px'] - offset_y
+            valid_data = valid_data[
+                (valid_data['x_px'] >= 0) & (valid_data['x_px'] <= img_w) &
+                (valid_data['y_px'] >= 0) & (valid_data['y_px'] <= img_h)
+            ]
         
         if not valid_data.empty:
             # Create 2D histogram
             hist, x_edges, y_edges = np.histogram2d(
                 valid_data['x_px'], valid_data['y_px'],
-                bins=bins, range=[[0, screen_w], [0, screen_h]]
+                bins=bins, range=[[0, img_w], [0, img_h]]
             )
             
             # Apply Gaussian filter for smoothing
@@ -197,7 +232,7 @@ def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str],
     for i, (heat, label) in enumerate(zip(heatmaps, labels)):
         ax = fig.add_subplot(n_rows, n_cols, i+1)
         im = ax.imshow(
-            heat.T, extent=[0, screen_w, screen_h, 0],
+            heat.T, extent=[0, img_w, img_h, 0],
             cmap=cmap
         )
         plt.colorbar(im, ax=ax, label='Density')
@@ -210,7 +245,7 @@ def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str],
         ax = fig.add_subplot(n_rows, n_cols, 3)
         diff = heatmaps[0] - heatmaps[1]
         im = ax.imshow(
-            diff.T, extent=[0, screen_w, screen_h, 0],
+            diff.T, extent=[0, img_w, img_h, 0],
             cmap='coolwarm'
         )
         plt.colorbar(im, ax=ax, label='Difference')
@@ -222,10 +257,15 @@ def plot_group_heatmap(dfs: List[pd.DataFrame], labels: List[str],
     return fig
 
 
-def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
-                 screen_size: Tuple[int, int] = (1920, 1080),
-                 show_fixations: bool = True, min_duration_s: float = 0.1,
-                 background_image: Optional[str] = None) -> Figure:
+def plot_scanpath(
+    df: pd.DataFrame,
+    fig: Optional[Figure] = None,
+    screen_size: Tuple[int, int] = (1920, 1080),
+    image_size: Optional[Tuple[int, int]] = None,
+    show_fixations: bool = True,
+    min_duration_s: float = 0.1,
+    background_image: Optional[str] = None,
+) -> Figure:
     """
     Plot scanpath trajectory.
     
@@ -237,6 +277,9 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
         Matplotlib figure to plot on, by default None
     screen_size : Tuple[int, int], optional
         Screen dimensions (width, height), by default (1920, 1080)
+    image_size : Optional[Tuple[int, int]], optional
+        Stimulus image dimensions (width, height). If provided the data is
+        centered within the screen dimensions, by default None
     show_fixations : bool, optional
         Whether to show fixations as circles, by default True
     min_duration_s : float, optional
@@ -260,13 +303,21 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
     if background_image:
         try:
             img = plt.imread(background_image)
-            ax.imshow(img, extent=[0, screen_w, screen_h, 0])
+            ax.imshow(img, extent=[0, img_w, img_h, 0])
         except Exception as e:
             print(f"Error loading background image: {e}")
     
     # Filter for valid coordinates
     valid_data = df.dropna(subset=['x_px', 'y_px'])
-    
+    if image_size:
+        valid_data = valid_data.copy()
+        valid_data['x_px'] = valid_data['x_px'] - offset_x
+        valid_data['y_px'] = valid_data['y_px'] - offset_y
+        valid_data = valid_data[
+            (valid_data['x_px'] >= 0) & (valid_data['x_px'] <= img_w) &
+            (valid_data['y_px'] >= 0) & (valid_data['y_px'] <= img_h)
+        ]
+
     if not valid_data.empty:
         # Plot raw gaze trajectory
         ax.plot(valid_data['x_px'], valid_data['y_px'], '-', alpha=0.5, linewidth=1, color='blue')
@@ -285,8 +336,8 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
                 )
     
     # Set plot limits and labels
-    ax.set_xlim(0, screen_w)
-    ax.set_ylim(screen_h, 0)  # Invert Y axis to match screen coordinates
+    ax.set_xlim(0, img_w)
+    ax.set_ylim(img_h, 0)  # Invert Y axis to match screen coordinates
     ax.set_xlabel('X (px)')
     ax.set_ylabel('Y (px)')
     ax.set_title('Scanpath Trajectory')
@@ -294,10 +345,11 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
     return fig
 
 
-def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame, 
+def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
                            output_dir: str, subject: Optional[str] = None,
                            stimulus: Optional[str] = None,
                            screen_size: Tuple[int, int] = (1920, 1080),
+                           image_size: Optional[Tuple[int, int]] = None,
                            background_image: Optional[str] = None,
                            transition_matrix: Optional[pd.DataFrame] = None) -> None:
     """
@@ -317,6 +369,9 @@ def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
         Stimulus ID to filter by, by default None
     screen_size : Tuple[int, int], optional
         Screen dimensions (width, height), by default (1920, 1080)
+    image_size : Optional[Tuple[int, int]], optional
+        Stimulus image dimensions (width, height). If provided the data is
+        centered within the screen dimensions, by default None
     background_image : Optional[str], optional
         Path to background image, by default None
     transition_matrix : Optional[pd.DataFrame], optional
@@ -351,6 +406,7 @@ def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
         fig = plot_scanpath(
             filtered_fixations,
             screen_size=screen_size,
+            image_size=image_size,
             background_image=background_image,
         )
         fig.savefig(output_path / f"{prefix}scanpath.png", dpi=300, bbox_inches='tight')
@@ -361,6 +417,7 @@ def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
         fig = plot_heatmap(
             filtered_fixations,
             screen_size=screen_size,
+            image_size=image_size,
             background_image=background_image,
         )
         fig.savefig(output_path / f"{prefix}heatmap.png", dpi=300, bbox_inches='tight')

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -144,6 +144,12 @@ class MainWindow(QMainWindow):
         self.current_subject = None
         self.current_stimulus = None
         self.background_images: Dict[str, str] = {}
+
+        # Display settings
+        self.screen_width = 1920
+        self.screen_height = 1080
+        self.image_width = 800
+        self.image_height = 800
         
         # UI setup
         self.setup_ui()
@@ -192,7 +198,13 @@ class MainWindow(QMainWindow):
         self.toolbar.addAction(self.experiment_action)
 
         self.toolbar.addSeparator()
-        
+
+        self.settings_action = QAction("Settings", self)
+        self.settings_action.triggered.connect(self.open_settings_dialog)
+        self.toolbar.addAction(self.settings_action)
+
+        self.toolbar.addSeparator()
+
         self.export_action = QAction("Export Results", self)
         self.export_action.triggered.connect(self.export_dialog)
         self.toolbar.addAction(self.export_action)
@@ -406,6 +418,44 @@ class MainWindow(QMainWindow):
             for path in dialog.selectedFiles():
                 stim_id = extract_stimulus_id(path)
                 self.background_images[stim_id] = path
+
+    def open_settings_dialog(self):
+        """Dialog for adjusting display settings."""
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Display Settings")
+        layout = QFormLayout(dlg)
+
+        sw_spin = QSpinBox()
+        sw_spin.setRange(100, 10000)
+        sw_spin.setValue(self.screen_width)
+        layout.addRow("Screen Width:", sw_spin)
+
+        sh_spin = QSpinBox()
+        sh_spin.setRange(100, 10000)
+        sh_spin.setValue(self.screen_height)
+        layout.addRow("Screen Height:", sh_spin)
+
+        iw_spin = QSpinBox()
+        iw_spin.setRange(100, 10000)
+        iw_spin.setValue(self.image_width)
+        layout.addRow("Image Width:", iw_spin)
+
+        ih_spin = QSpinBox()
+        ih_spin.setRange(100, 10000)
+        ih_spin.setValue(self.image_height)
+        layout.addRow("Image Height:", ih_spin)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        layout.addRow(buttons)
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+
+        if dlg.exec() == QDialog.Accepted:
+            self.screen_width = sw_spin.value()
+            self.screen_height = sh_spin.value()
+            self.image_width = iw_spin.value()
+            self.image_height = ih_spin.value()
+            self.update_plots()
     
     def export_dialog(self):
         """Show dialog to export results."""
@@ -641,7 +691,12 @@ class MainWindow(QMainWindow):
                 image_path = self.background_images.get(str(self.current_stimulus))
 
             # Update heatmap plot
-            fig = plot_heatmap(raw_data, background_image=image_path)
+            fig = plot_heatmap(
+                raw_data,
+                screen_size=(self.screen_width, self.screen_height),
+                image_size=(self.image_width, self.image_height),
+                background_image=image_path,
+            )
             self.heatmap_plot.set_figure(fig)
    
 
@@ -658,7 +713,12 @@ class MainWindow(QMainWindow):
                 ax.set_title('No Scanpath Data')
                 self.scanpath_tab.set_figure(fig)
             else:
-                fig = plot_scanpath(fixations, background_image=image_path)
+                fig = plot_scanpath(
+                    fixations,
+                    screen_size=(self.screen_width, self.screen_height),
+                    image_size=(self.image_width, self.image_height),
+                    background_image=image_path,
+                )
                 self.scanpath_tab.set_figure(fig)
             
             # Update metrics plot
@@ -755,7 +815,14 @@ class MainWindow(QMainWindow):
         group_labels = list(df[group_var].dropna().unique())
         group_dfs = [self.fixations[self.fixations[group_var] == g] for g in group_labels]
         try:
-            fig = plot_group_heatmap(group_dfs, group_labels, bins=bins, sigma=sigma)
+            fig = plot_group_heatmap(
+                group_dfs,
+                group_labels,
+                bins=bins,
+                sigma=sigma,
+                screen_size=(self.screen_width, self.screen_height),
+                image_size=(self.image_width, self.image_height),
+            )
             self.group_plot.set_figure(fig)
         except Exception as e:
             QMessageBox.warning(self, "Plot Error", f"Could not plot group heatmap: {str(e)}")
@@ -803,7 +870,14 @@ class MainWindow(QMainWindow):
         group_dfs = [self.fixations[self.fixations[group_var] == g] for g in group_labels]
         
         try:
-            fig = plot_group_heatmap(group_dfs, group_labels, bins=bins, sigma=sigma)
+            fig = plot_group_heatmap(
+                group_dfs,
+                group_labels,
+                bins=bins,
+                sigma=sigma,
+                screen_size=(self.screen_width, self.screen_height),
+                image_size=(self.image_width, self.image_height),
+            )
             self.group_plot.set_figure(fig)
         except Exception as e:
             QMessageBox.warning(self, "Plot Error", f"Could not plot group heatmap: {str(e)}")
@@ -845,6 +919,8 @@ class MainWindow(QMainWindow):
                 stimulus=self.current_stimulus,
                 background_image=self.background_images.get(str(self.current_stimulus)) if self.current_stimulus else None,
                 transition_matrix=transitions,
+                screen_size=(self.screen_width, self.screen_height),
+                image_size=(self.image_width, self.image_height),
             )
             
             self.statusBar.showMessage(f"Results exported to {output_dir}")


### PR DESCRIPTION
## Summary
- introduce display settings in GUI with toolbar action
- pass screen and image size settings to visualization functions
- extend visualization functions to accept image dimensions
- propagate parameters through analysis run and export routines

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m analysis.run --help` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686801a43ff88326a197bec2f190c0b2