### PR TITLE
Implement letterboxed background images for gaze plots

### DIFF
--- a/analysis/viz.py
+++ b/analysis/viz.py
@@ -43,10 +43,16 @@ def plot_gaze_timeseries(df: pd.DataFrame, fig: Optional[Figure] = None) -> Figu
     return fig
 
 
-def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None, 
-                bins: int = 200, sigma: int = 10,
-                screen_size: Tuple[int, int] = (1920, 1080),
-                cmap: str = 'viridis', alpha: float = 0.7) -> Figure:
+def plot_heatmap(
+    df: pd.DataFrame,
+    fig: Optional[Figure] = None,
+    bins: int = 200,
+    sigma: int = 10,
+    screen_size: Tuple[int, int] = (1920, 1080),
+    cmap: str = 'viridis',
+    alpha: float = 0.7,
+    background_image: Optional[str] = None,
+) -> Figure:
     """
     Plot gaze heatmap.
     
@@ -66,6 +72,10 @@ def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None,
         Colormap name, by default 'viridis'
     alpha : float, optional
         Heatmap transparency, by default 0.7
+    background_image : Optional[str], optional
+        Path to a background image. If provided, the image is scaled to fit
+        the plot height while preserving its aspect ratio and centered
+        horizontally with black side bars.
     
     Returns:
     --------
@@ -79,9 +89,27 @@ def plot_heatmap(df: pd.DataFrame, fig: Optional[Figure] = None,
     
     # Filter for valid coordinates
     valid_data = df.dropna(subset=['x_px', 'y_px'])
-    
+
     # Create heatmap
     ax = fig.add_subplot(111)
+
+    # Prepare background image
+    if background_image:
+        try:
+            img = plt.imread(background_image)
+            img_h, img_w = img.shape[:2]
+            scale = screen_h / img_h
+            disp_w = img_w * scale
+            offset = (screen_w - disp_w) / 2
+            ax.set_facecolor('black')
+            ax.imshow(
+                img,
+                extent=[offset, offset + disp_w, screen_h, 0],
+                aspect='auto',
+                zorder=0,
+            )
+        except Exception as e:
+            print(f"Error loading background image: {e}")
     
     if not valid_data.empty:
         # Create 2D histogram
@@ -229,7 +257,9 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
     min_duration_s : float, optional
         Minimum fixation duration to show, by default 0.1
     background_image : Optional[str], optional
-        Path to background image, by default None
+        Path to a background image. If provided, the image is scaled to the
+        plot height while maintaining its aspect ratio and centered with
+        black bars on the sides.
     
     Returns:
     --------
@@ -247,7 +277,17 @@ def plot_scanpath(df: pd.DataFrame, fig: Optional[Figure] = None,
     if background_image:
         try:
             img = plt.imread(background_image)
-            ax.imshow(img, extent=[0, screen_w, screen_h, 0])
+            img_h, img_w = img.shape[:2]
+            scale = screen_h / img_h
+            disp_w = img_w * scale
+            offset = (screen_w - disp_w) / 2
+            ax.set_facecolor('black')
+            ax.imshow(
+                img,
+                extent=[offset, offset + disp_w, screen_h, 0],
+                aspect='auto',
+                zorder=0,
+            )
         except Exception as e:
             print(f"Error loading background image: {e}")
     
@@ -394,7 +434,8 @@ def save_all_visualizations(fixations: pd.DataFrame, metrics: pd.DataFrame,
     if not filtered_fixations.empty:
         fig = plot_heatmap(
             filtered_fixations,
-            screen_size=screen_size
+            screen_size=screen_size,
+            background_image=background_image,
         )
         fig.savefig(output_path / f"{prefix}heatmap.png", dpi=300, bbox_inches='tight')
         plt.close(fig)

--- a/gui/viewer.py
+++ b/gui/viewer.py
@@ -517,8 +517,15 @@ class MainWindow(QMainWindow):
             else:
                 print("Warning: timeseries_tab missing set_figure")
             
+            # Determine background image path if available
+            bg_img = None
+            if self.current_stimulus:
+                img_path = Path('data/current_images') / f"{self.current_stimulus}.jpg"
+                if img_path.exists():
+                    bg_img = str(img_path)
+
             # Update heatmap plot
-            fig = plot_heatmap(raw_data)
+            fig = plot_heatmap(raw_data, background_image=bg_img)
             if hasattr(self.heatmap_tab, "set_figure"):
                 self.heatmap_tab.set_figure(fig)
             else:
@@ -540,7 +547,7 @@ class MainWindow(QMainWindow):
                 else:
                     print("Warning: scanpath_tab missing set_figure")
             else:
-                fig = plot_scanpath(fixations)
+                fig = plot_scanpath(fixations, background_image=bg_img)
                 if hasattr(self.scanpath_tab, "set_figure"):
                     self.scanpath_tab.set_figure(fig)
                 else:


### PR DESCRIPTION
## Summary
- add optional `background_image` arg to `plot_heatmap` and handle scaling/centering
- letterbox background image in `plot_scanpath` the same way
- look for stimulus images in `data/current_images` when updating plots

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686810fe1e688326bb477e2feecaff48