### PR TITLE
Make heatmap and scanpath letterboxes transparent

### DIFF
--- a/analysis/viz.py
+++ b/analysis/viz.py
@@ -143,7 +143,9 @@ def plot_heatmap(
     ax = fig.add_subplot(111)
 
     # Add background image if provided
-    ax.set_facecolor("black")
+    # Use a transparent background so letterboxes don't appear
+    fig.patch.set_alpha(0)
+    ax.set_facecolor("none")
     if background_image:
         try:
             img = plt.imread(background_image)
@@ -376,7 +378,9 @@ def plot_scanpath(
     ax = fig.add_subplot(111)
 
     # Add background image if provided
-    ax.set_facecolor("black")
+    # Use a transparent background so letterboxes don't appear
+    fig.patch.set_alpha(0)
+    ax.set_facecolor("none")
     if background_image:
         try:
             img = plt.imread(background_image)


### PR DESCRIPTION
## Summary
- switch Matplotlib background for heatmap and scanpath to transparent

## Testing
- `python -m py_compile analysis/viz.py`

------
https://chatgpt.com/codex/tasks/task_e_68752db066788326ad90cb5e6fd1df4c